### PR TITLE
Runtime 44

### DIFF
--- a/org.midori_browser.Midori.json
+++ b/org.midori_browser.Midori.json
@@ -19,6 +19,7 @@
   ],
   "modules": [
     "shared-modules/intltool/intltool-0.51.json",
+    "shared-modules/libsoup/libsoup-2.4.json",
     {
       "name": "libpeas",
       "buildsystem": "meson",
@@ -29,9 +30,51 @@
       ],
       "sources": [
         {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libpeas.git",
-          "tag": "libpeas-1.32.0"
+          "type": "archive",
+          "url": "https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz",
+          "sha256": "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c",
+          "x-checker-data": {
+            "type": "gnome",
+            "name": "libpeas"
+          }
+        }
+      ]
+    },
+    {
+      "name": "unifdef",
+      "no-autogen": true,
+      "make-install-args": [
+          "prefix=${FLATPAK_DEST}"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://dotat.at/prog/unifdef/unifdef-2.12.tar.xz",
+          "sha256": "43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400"
+        }
+      ],
+      "cleanup": [ "*" ]
+    },
+    {
+      "name": "webkit2gtk-4.0",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DPORT=GTK",
+        "-DENABLE_BUBBLEWRAP_SANDBOX=OFF",
+        "-DENABLE_DOCUMENTATION=OFF",
+        "-DUSE_SOUP2=ON"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://webkitgtk.org/releases/webkitgtk-2.40.5.tar.xz",
+          "sha256": "7de051a263668621d91a61a5eb1c3771d1a7cec900043d4afef06c326c16037f",
+          "x-checker-data": {
+            "type": "html",
+            "url": "https://webkitgtk.org/releases/",
+            "version-pattern": "LATEST-STABLE-(\\d[\\.\\d]+\\d)",
+            "url-template": "https://webkitgtk.org/releases/webkitgtk-$version.tar.xz"
+          }
         }
       ]
     },

--- a/org.midori_browser.Midori.json
+++ b/org.midori_browser.Midori.json
@@ -2,7 +2,7 @@
   "app-id": "org.midori_browser.Midori",
   "branch": "stable",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "42",
+  "runtime-version": "44",
   "sdk": "org.gnome.Sdk",
   "command": "midori",
   "finish-args" : [


### PR DESCRIPTION
Closes https://github.com/flathub/org.midori_browser.Midori/pull/7

Runtimes >=42 doesn't have webkit2gtk compiled with libsoup-2.4. So bundle that. Since webkit2gtk is security sensitive library add x-checker so that it'll auto open PRs whenever there's an update. Add x-checker to libpeas as well.

libsoup2 is no longer developed.

Downsides: Makes the build complicated and long

I wonder how much longer it is viable to keep this version of Midori alive. The work is only going to increase with each runtime as more legacy libraries are stripped. 

It's a browser, last commit was 4 years ago and it feels _unsafe_
